### PR TITLE
add transposition table

### DIFF
--- a/src/chess/board.cpp
+++ b/src/chess/board.cpp
@@ -3,6 +3,7 @@
 Board::Board(const std::string& fen)
 {
     this->set_fen(fen);
+    this->history.reserve(512);
 };
 
 void Board::set_fen(const std::string& fen)
@@ -410,7 +411,7 @@ void Board::make(u16 move)
     assert(this->get_color_at(move_to) != this->color || move_type == move::type::CASTLING);
 
     // Saves info
-    this->history.add(Undo {
+    this->history.push_back(Undo {
         .hash = this->hash,
         .castling = this->castling,
         .enpassant = this->enpassant,
@@ -552,7 +553,7 @@ void Board::unmake(u16 move)
 {
     // Reverts history
     auto undo = this->history.back();
-    this->history.pop();
+    this->history.pop_back();
 
     this->hash = undo.hash;
     this->castling = undo.castling;
@@ -623,7 +624,7 @@ void Board::unmake(u16 move)
 void Board::make_null()
 {
     // Saves info
-    this->history.add(Undo {
+    this->history.push_back(Undo {
         .hash = this->hash,
         .castling = this->castling,
         .enpassant = this->enpassant,
@@ -649,7 +650,7 @@ void Board::unmake_null()
 {
     // Reverts history
     auto undo = this->history.back();
-    this->history.pop();
+    this->history.pop_back();
 
     this->hash = undo.hash;
     this->castling = undo.castling;

--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -5,6 +5,8 @@
 
 #include "../util/arrayvec.h"
 
+constexpr i32 MAX_PLY = 256;
+
 struct Undo
 {
     u64 hash;
@@ -18,7 +20,6 @@ class Board
 {
 public:
     static constexpr auto STARTPOS = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
-    static constexpr auto MAX_PLY = 256;
 private:
     u64 pieces[6];
     u64 colors[2];
@@ -30,7 +31,7 @@ private:
     i32 ply;
 private:
     u64 hash;
-    arrayvec<Undo, MAX_PLY> history;
+    std::vector<Undo> history;
 public:
     Board(const std::string& fen = STARTPOS);
 public:

--- a/src/chess/movegen.h
+++ b/src/chess/movegen.h
@@ -5,24 +5,19 @@
 
 #include "../util/arrayvec.h"
 
-namespace move::generate::type
+namespace move::generate
 {
 
-enum : i8
+enum class type : i8
 {
     ALL,
     NOISY,
     QUIET
 };
 
-};
-
-namespace move::generate
-{
-
 // Gets the check mask for a color
 // Gets the mask for all the enemy's attackers and their lines of attack
-template<i8 COLOR>
+template <i8 COLOR>
 inline std::pair<u64, i32> get_check_mask(Board &board, i8 square)
 {
     const u64 occupied = board.get_occupied();
@@ -78,7 +73,7 @@ inline std::pair<u64, i32> get_check_mask(Board &board, i8 square)
 };
 
 // Gets the ray masks of the enemy rooks that pin our pieces
-template<i8 COLOR>
+template <i8 COLOR>
 inline u64 get_pin_mask_rook(Board &board, i8 square)
 {
     const u64 occupied_us = board.get_colors(COLOR);
@@ -106,7 +101,7 @@ inline u64 get_pin_mask_rook(Board &board, i8 square)
 };
 
 // Gets the ray masks of the enemy bishops that pin our pieces
-template<i8 COLOR>
+template <i8 COLOR>
 inline u64 get_pin_mask_bishop(Board &board, i8 square)
 {
     const u64 occupied_us = board.get_colors(COLOR);
@@ -134,7 +129,7 @@ inline u64 get_pin_mask_bishop(Board &board, i8 square)
 };
 
 // Gets the mask of all seen squares
-template<i8 COLOR>
+template <i8 COLOR>
 inline u64 get_seen_mask(Board &board, u64 enemy_empty)
 {
     i8 enemy_king_square = board.get_king_square(!COLOR);
@@ -188,7 +183,7 @@ inline u64 get_seen_mask(Board &board, u64 enemy_empty)
 };
 
 // Gets the mask of all the castle-possible rooks
-template<i8 TYPE, i8 COLOR>
+template <type TYPE, i8 COLOR>
 inline u64 get_castle_rook_mask(Board& board, u64 seen_mask, u64 pin_mask_rook)
 {
     if constexpr (TYPE == move::generate::type::NOISY) {
@@ -241,7 +236,7 @@ inline u64 get_castle_rook_mask(Board& board, u64 seen_mask, u64 pin_mask_rook)
 };
 
 // Adds pawn moves to the move list
-template<i8 TYPE, i8 COLOR>
+template <type TYPE, i8 COLOR>
 inline void push_pawn(arrayvec<u16, MAX_MOVE>& list, Board& board, u64 check_mask, u64 pin_mask_rook, u64 pin_mask_bishop)
 {
     constexpr i8 UP = direction::get_color_direction(direction::NORTH, COLOR);
@@ -407,7 +402,7 @@ inline void push_pawn(arrayvec<u16, MAX_MOVE>& list, Board& board, u64 check_mas
 };
 
 // Helper function
-template<typename T>
+template <typename T>
 inline void while_mask_add(arrayvec<u16, MAX_MOVE>& list, u64 mask, T callback)
 {
     while (mask)
@@ -428,7 +423,7 @@ inline void while_mask_add(arrayvec<u16, MAX_MOVE>& list, u64 mask, T callback)
 }
 
 // Gets all legal moves
-template<i8 TYPE, i8 COLOR>
+template <type TYPE, i8 COLOR>
 inline arrayvec<u16, MAX_MOVE> get_legal(Board& board)
 {
     auto list = arrayvec<u16, MAX_MOVE>();
@@ -541,7 +536,7 @@ inline arrayvec<u16, MAX_MOVE> get_legal(Board& board)
 };
 
 // Gets all legal moves for the side to move of this board
-template<i8 TYPE>
+template <type TYPE>
 inline arrayvec<u16, MAX_MOVE> get_legal(Board& board)
 {
     if (board.get_color() == color::WHITE) {

--- a/src/chess/types.h
+++ b/src/chess/types.h
@@ -8,13 +8,17 @@
 
 #include <functional>
 #include <utility>
+#include <cstdio>
 #include <cstdint>
 #include <cstddef>
+#include <cstdlib>
 #include <algorithm>
 #include <bit>
 #include <bitset>
 #include <cassert>
 #include <chrono>
+#include <stdio.h>
+#include <stdlib.h>
 
 #include <vector>
 #include <array>
@@ -29,11 +33,13 @@ using i8 = int8_t;
 using i16 = int16_t;
 using i32 = int32_t;
 using i64 = int64_t;
+using i128 = __int128;
 
 using u8 = uint8_t;
 using u16 = uint16_t;
 using u32 = uint32_t;
 using u64 = uint64_t;
+using u128 = unsigned __int128;
 
 using f32 = float;
 using f64 = double;

--- a/src/eval.h
+++ b/src/eval.h
@@ -6,7 +6,9 @@ namespace eval::score
 {
 
 constexpr i32 DRAW = 0;
-constexpr i32 MATE = INT16_MAX - 1;
+constexpr i32 MATE = 32000 + MAX_PLY;
+constexpr i32 MATE_FOUND = MATE - MAX_PLY;
+constexpr i32 NONE = MATE + 1;
 constexpr i32 INFINITE = INT16_MAX;
 
 constexpr i32 create(i32 midgame, i32 endgame)
@@ -56,11 +58,11 @@ struct Weight
 
 constexpr Weight DEFAULT = Weight {
     .material_pawn = 100,
-    .material_knight = 300,
+    .material_knight = 320,
     .material_bishop = 330,
     .material_rook = 500,
     .material_queen = 900,
-    .material_king = 1000,
+    .material_king = 10000,
 
     .table = {
         {
@@ -127,8 +129,8 @@ constexpr Weight DEFAULT = Weight {
 
     .mobility_knight = 10,
     .mobility_bishop = 5,
-    .mobility_rook = 5,
-    .mobility_queen = 5,
+    .mobility_rook = 0,
+    .mobility_queen = 0,
     .mobility_king = 0,
 
     .tempo = 20

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,11 +5,15 @@ int main()
     init();
 
     auto board = Board();
-    auto info = search::Info();
+    auto settings = search::Settings();
     auto engine = search::Engine();
 
     const std::string NAME = "blueberry v0.1";
     const std::string AUTHOR = "citrus610";
+
+    // Init table
+    // TODO: remove this and move it to when uci sends options
+    engine.init();
 
     while (true)
     {
@@ -48,7 +52,7 @@ int main()
 
         if (tokens[0] == "ucinewgame") {
             board = Board();
-            info = search::Info();
+            settings = search::Settings();
 
             engine.stop();
             engine.clear();
@@ -65,25 +69,26 @@ int main()
 
             board = board_uci.value();
 
+            std::cout << board.get_fen() << std::endl;
+
             continue;
         }
 
         if (tokens[0] == "go") {
             // Reads go infos
-            auto info_uci = uci::get_command_go(input);
+            auto settings_uci = uci::get_command_go(input);
 
-            if (!info_uci.has_value()) {
+            if (!settings_uci.has_value()) {
                 continue;
             }
 
-            info = info_uci.value();
+            settings = settings_uci.value();
 
             // Stops thread
             engine.stop();
-            engine.clear();
 
             // Starts search thread
-            engine.search(board, info);
+            engine.search(board, settings);
 
             continue;
         }
@@ -91,7 +96,6 @@ int main()
         if (tokens[0] == "stop") {
             // Stops thread
             engine.stop();
-            engine.clear();
 
             continue;
         }
@@ -99,7 +103,6 @@ int main()
         if (tokens[0] == "quit" || tokens[0] == "exit") {
             // Stops thread
             engine.stop();
-            engine.clear();
 
             break;
         }

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -4,11 +4,17 @@
 namespace move::order
 {
 
-arrayvec<i32, move::MAX_MOVE> get_score(const arrayvec<u16, move::MAX_MOVE>& moves, search::Data& data)
+arrayvec<i32, move::MAX_MOVE> get_score(const arrayvec<u16, move::MAX_MOVE>& moves, search::Data& data, u16 hash_move)
 {
     auto scores = arrayvec<i32, move::MAX_MOVE>();
 
     for (usize i = 0; i < moves.size(); ++i) {
+        // Hash move
+        if (moves[i] == hash_move) {
+            scores.add(move::order::HASH_SCORE);
+            continue;
+        }
+
         // MVV LVA
         i8 piece = data.board.get_piece_at(move::get_square_from(moves[i]));
         i8 captured = data.board.get_piece_type_at(move::get_square_to(moves[i]));
@@ -33,9 +39,9 @@ arrayvec<i32, move::MAX_MOVE> get_score(const arrayvec<u16, move::MAX_MOVE>& mov
 
 void sort(arrayvec<u16, move::MAX_MOVE>& moves, arrayvec<i32, move::MAX_MOVE>& moves_scores, usize index)
 {
-    usize best = 0;
+    usize best = index;
 
-    for (usize i = index; i < moves.size(); ++i) {
+    for (usize i = index + 1; i < moves.size(); ++i) {
         if (moves_scores[i] > moves_scores[best]) {
             best = i;
         }

--- a/src/order.h
+++ b/src/order.h
@@ -20,11 +20,11 @@ constexpr i32 MVV_LVA[5][6] = {
     { 550, 540, 530, 520, 510, 500 }
 };
 
-constexpr i32 PV_SCORE = 100000;
+constexpr i32 HASH_SCORE = 100000;
 constexpr i32 MVV_LVA_SCORE = 10000;
 constexpr i32 KILLER_SCORE = 9000;
 
-arrayvec<i32, move::MAX_MOVE> get_score(const arrayvec<u16, move::MAX_MOVE>& moves, search::Data& data);
+arrayvec<i32, move::MAX_MOVE> get_score(const arrayvec<u16, move::MAX_MOVE>& moves, search::Data& data, u16 hash_move);
 
 void sort(arrayvec<u16, move::MAX_MOVE>& moves, arrayvec<i32, move::MAX_MOVE>& moves_scores, usize index);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -198,6 +198,10 @@ i32 Engine::pvsearch(Data& data, i32 alpha, i32 beta, i32 depth, PV& pv)
         return eval::score::DRAW;
     }
 
+    // Inits pv
+    pv.count = 0;
+    auto pv_next = PV();
+
     // Updates data
     data.nodes += 1;
     data.seldepth = std::max(data.seldepth, data.ply);
@@ -239,10 +243,7 @@ i32 Engine::pvsearch(Data& data, i32 alpha, i32 beta, i32 depth, PV& pv)
         }
     }
 
-    // Inits data
-    pv.count = 0;
-    auto pv_next = PV();
-
+    // Best score
     i32 best = -eval::score::INFINITE;
     u16 best_move = move::NONE_MOVE;
 
@@ -357,6 +358,10 @@ i32 Engine::qsearch(Data& data, i32 alpha, i32 beta, PV& pv)
         return eval::score::DRAW;
     }
 
+    // Inits pv
+    pv.count = 0;
+    auto pv_next = PV();
+
     // Updates data
     data.nodes += 1;
     data.seldepth = std::max(data.seldepth, data.ply);
@@ -392,10 +397,7 @@ i32 Engine::qsearch(Data& data, i32 alpha, i32 beta, PV& pv)
         }
     }
 
-    // Inits data
-    pv.count = 0;
-    auto pv_next = PV();
-
+    // Best score
     i32 best;
     u16 best_move = move::NONE_MOVE;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -121,6 +121,11 @@ bool Engine::search(Board uci_board, Settings uci_setting)
 
             uci::print_info(i, data.seldepth, score, data.nodes, dt, this->table.hashfull(), pv_history.back());
 
+            // Avoids searching too shallow
+            if (i < 4) {
+                continue;
+            }
+
             // Checks time
             if (!settings.infinite && timer::get_current() >= this->time_end_soft) {
                 this->running.clear();
@@ -380,11 +385,11 @@ i32 Engine::qsearch(Data& data, i32 alpha, i32 beta, PV& pv)
         i32 table_depth = table_entry->get_depth();
 
         // Returns when score is exact or produces a cutoff in pv nodes
-            if ((table_bound == transposition::bound::EXACT) ||
-                (table_bound == transposition::bound::LOWER && table_score >= beta) ||
-                (table_bound == transposition::bound::UPPER && table_score <= alpha)) {
-                return table_score;
-            }
+        if ((table_bound == transposition::bound::EXACT) ||
+            (table_bound == transposition::bound::LOWER && table_score >= beta) ||
+            (table_bound == transposition::bound::UPPER && table_score <= alpha)) {
+            return table_score;
+        }
     }
 
     // Inits data

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -11,7 +11,7 @@ PV::PV()
 
 void PV::clear()
 {
-    for (i32 i = 0; i < Board::MAX_PLY; ++i) {
+    for (i32 i = 0; i < MAX_PLY; ++i) {
         this->data[i] = move::NONE_MOVE;
     }
 
@@ -31,11 +31,7 @@ void PV::update(u16 move, const PV& other)
 
 void Data::clear()
 {
-    for (i32 i = 0; i < Board::MAX_PLY; ++i) {
-        this->pv_table[i].clear();
-    }
-
-    for (i32 i = 0; i < Board::MAX_PLY; ++i) {
+    for (i32 i = 0; i < MAX_PLY; ++i) {
         this->killer_table[i] = move::NONE_MOVE;
     }
 
@@ -50,6 +46,7 @@ void Data::clear()
     this->ply = 0;
 
     this->nodes = 0;
+    this->seldepth = 0;
 };
 
 Engine::Engine()
@@ -57,86 +54,93 @@ Engine::Engine()
     this->clear();
 };
 
+void Engine::init()
+{
+    this->table.init(2);
+};
+
 void Engine::clear()
 {
     this->running.clear();
     this->thread = nullptr;
+
+    this->table.clear();
 };
 
-bool Engine::search(Board uci_board, Info uci_info)
+bool Engine::search(Board uci_board, Settings uci_setting)
 {
     if (this->running.test() || this->thread != nullptr) {
         return false;
     }
 
-    this->clear();
+    // Updates table
+    this->table.update();
+
+    // Sets search time
+    u64 time_start = timer::get_current();
+
+    this->time_end_soft = time_start + timer::get_available_soft(uci_setting.time[uci_board.get_color()], uci_setting.inc[uci_board.get_color()], uci_setting.movestogo);
+    this->time_end_hard = time_start + timer::get_available_hard(uci_setting.time[uci_board.get_color()]);
+
+    if (uci_setting.infinite) {
+        this->time_end_soft = UINT64_MAX;
+        this->time_end_hard = UINT64_MAX;
+    }
 
     // Starts search thread
     this->running.test_and_set();
 
-    this->thread = new std::thread([&] (Board board, Info info) {
-        // Total search time
-        u64 time = 0;
-
+    this->thread = new std::thread([&] (Board board, Settings settings) {
         // Storing best pv lines found in each iteration
         std::vector<PV> pv_history = {};
 
         // Iterative deepening
-        for (i32 i = 1; i < info.depth; ++i) {
+        for (i32 i = 1; i < settings.depth; ++i) {
             // Inits search data
             Data data;
             data.clear();
 
             data.board = board;
 
+            auto pv = PV();
+
             // Does negamax with alpha beta
             auto time_1 = std::chrono::high_resolution_clock::now();
 
-            i32 score = search::negamax(data, -eval::score::INFINITE, eval::score::INFINITE, i, running);
+            i32 score = this->negamax(data, -eval::score::INFINITE, eval::score::INFINITE, i, pv);
 
             auto time_2 = std::chrono::high_resolution_clock::now();
 
-            // Stops when the uci client sends stop
-            // We don't save the pv line when we stop the search abruptly
-            if (!this->running.test()) {
-                break;
-            }
-
             // Saves pv line
-            pv_history.push_back(data.pv_table[0]);
+            if (pv.count != 0 && pv.data[0] != move::NONE_MOVE) {
+                pv_history.push_back(pv);
+            }
 
             // Prints infos
             u64 dt = std::chrono::duration_cast<std::chrono::milliseconds>(time_2 - time_1).count();
 
-            uci::print_info(i, score, data.nodes, dt, pv_history.back());
+            uci::print_info(i, data.seldepth, score, data.nodes, dt, this->table.hashfull(), pv_history.back());
 
             // Checks time
-            time += dt;
-
-            // For now we only do max depth 7
-            // Because depth >= 8 search are super slow without transposition table
-            // TODO: will remove this later
-            if (i >= 7 && data.nodes >= 1000000) {
+            if (!settings.infinite && timer::get_current() >= this->time_end_soft) {
                 this->running.clear();
-                break;
             }
 
-            if (!info.infinite && time >= timer::get_available(info.time[board.get_color()], info.inc[board.get_color()], info.movestogo)) {
-                this->running.clear();
+            if (!this->running.test()) {
                 break;
             }
         }
 
         // Prints best move
         uci::print_bestmove(pv_history.back().data[0]);
-    }, uci_board, uci_info);
+    }, uci_board, uci_setting);
 
     return true;
 };
 
 bool Engine::stop()
 {
-    if (!this->running.test() || this->thread == nullptr) {
+    if (this->thread == nullptr) {
         return false;
     }
 
@@ -164,32 +168,79 @@ bool Engine::join()
 };
 
 // Alpha-beta
-i32 negamax(Data& data, i32 alpha, i32 beta, i32 depth, std::atomic_flag& running)
+i32 Engine::negamax(Data& data, i32 alpha, i32 beta, i32 depth, PV& pv)
 {
     // Quiensence search
     if (depth <= 0) {
-        return search::qsearch(data, alpha, beta, running);
+        return this->qsearch(data, alpha, beta, pv);
     }
 
-    // Updates nodes count
+    // Aborts search
+    if ((data.nodes & 0xFFF) == 0) {
+        u64 time_now = timer::get_current();
+
+        if (time_now >= this->time_end_hard) {
+            this->running.clear();
+        }
+    }
+
+    if (!this->running.test()) {
+        return eval::score::DRAW;
+    }
+
+    // Updates data
     data.nodes += 1;
+    data.seldepth = std::max(data.seldepth, data.ply);
+
+    // Init pv
+    pv.count = 0;
+    auto pv_next = PV();
 
     // Checks drawn
     if (data.board.is_drawn_repitition() || data.board.is_drawn_fifty_move() || data.board.is_drawn_insufficient()) {
         return i32(data.nodes & 0b10) - 1;
     }
 
-    // Aborts search
-    if (!running.test()) {
-        return -eval::score::INFINITE;
+    // Mate distance pruning
+    alpha = std::max(alpha, data.ply - eval::score::MATE);
+    beta = std::min(beta, eval::score::MATE - data.ply - 1);
+
+    if (alpha >= beta) {
+        return alpha;
+    }
+
+    // Probes table
+    auto [table_hit, table_entry] = this->table.get(data.board.get_hash());
+
+    u16 table_move = move::NONE_MOVE;
+
+    if (table_hit) {
+        table_move = table_entry->get_move();
+
+        u8 table_bound = table_entry->get_bound();
+        i32 table_score = table_entry->get_score(data.ply);
+        i32 table_depth = table_entry->get_depth();
+
+        // Checks if the same position has already been searched to at least an equal depth
+        // Returns when score is exact or produces a cutoff
+        if (table_depth >= depth) {
+            if ((table_bound == transposition::bound::EXACT) ||
+                (table_bound == transposition::bound::LOWER && table_score >= beta) ||
+                (table_bound == transposition::bound::UPPER && table_score <= alpha)) {
+                return table_score;
+            }
+        }
     }
 
     // Best score
     i32 best = -eval::score::INFINITE;
+    u16 best_move = move::NONE_MOVE;
+
+    i32 alpha_old = alpha;
 
     // Generate moves and scores them
     auto moves = move::generate::get_legal<move::generate::type::ALL>(data.board);
-    auto moves_scores = move::order::get_score(moves, data);
+    auto moves_scores = move::order::get_score(moves, data, table_move);
 
     // Continues searching
     for (usize i = 0; i < moves.size(); ++i) {
@@ -200,18 +251,27 @@ i32 negamax(Data& data, i32 alpha, i32 beta, i32 depth, std::atomic_flag& runnin
         data.board.make(moves[i]);
         data.ply += 1;
 
+        // Prefetch table
+        this->table.prefetch(data.board.get_hash());
+
         // Searchs deeper
-        i32 score = -search::negamax(data, -beta, -alpha, depth - 1, running);
+        i32 score = -this->negamax(data, -beta, -alpha, depth - 1, pv_next);
 
         // Unmakes
         data.board.unmake(moves[i]);
         data.ply -= 1;
+
+        // Aborts search
+        if (!this->running.test()) {
+            return eval::score::DRAW;
+        }
 
         bool is_quiet = data.board.get_piece_at(move::get_square_to(moves[i])) == piece::NONE || move::get_type(moves[i]) == move::type::CASTLING;
 
         // Updates values
         if (score > best) {
             best = score;
+            best_move = moves[i];
 
             if (score > alpha) {
                 alpha = score;
@@ -225,7 +285,7 @@ i32 negamax(Data& data, i32 alpha, i32 beta, i32 depth, std::atomic_flag& runnin
                 }
     
                 // Updates pv line
-                data.pv_table[data.ply].update(moves[i], data.pv_table[data.ply + 1]);
+                pv.update(moves[i], pv_next);
             }
         }
 
@@ -236,7 +296,7 @@ i32 negamax(Data& data, i32 alpha, i32 beta, i32 depth, std::atomic_flag& runnin
                 data.killer_table[data.ply] = moves[i];
             }
 
-            return best;
+            break;
         }
     }
 
@@ -246,23 +306,44 @@ i32 negamax(Data& data, i32 alpha, i32 beta, i32 depth, std::atomic_flag& runnin
             return -eval::score::MATE + data.ply;
         }
         else {
-            return eval::score::DRAW;
+            return i32(data.nodes & 0b10) - 1;
         }
     }
+
+    // Updates table
+    u8 bound =
+        best >= beta ? transposition::bound::LOWER :
+        best > alpha_old ? transposition::bound::EXACT :
+        transposition::bound::UPPER;
+    
+    table_entry->set(data.board.get_hash(), best_move, best, eval::score::NONE, depth, true, bound, data.ply, this->table.age);
 
     return best;
 };
 
 // Quiescence search
-i32 qsearch(Data& data, i32 alpha, i32 beta, std::atomic_flag& running)
+i32 Engine::qsearch(Data& data, i32 alpha, i32 beta, PV& pv)
 {
-    // Updates nodes count
-    data.nodes += 1;
-
     // Aborts search
-    if (!running.test()) {
-        return alpha;
+    if ((data.nodes & 0xFFF) == 0) {
+        u64 time_now = timer::get_current();
+
+        if (time_now >= this->time_end_hard) {
+            this->running.clear();
+        }
     }
+
+    if (!this->running.test()) {
+        return eval::score::DRAW;
+    }
+
+    // Updates data
+    data.nodes += 1;
+    data.seldepth = std::max(data.seldepth, data.ply);
+
+    // Init pv
+    pv.count = 0;
+    auto pv_next = PV();
 
     // Checks if we're in check
     bool is_in_check = data.board.is_in_check(data.board.get_color());
@@ -271,16 +352,39 @@ i32 qsearch(Data& data, i32 alpha, i32 beta, std::atomic_flag& running)
     i32 standpat = eval::get(data.board);
     
     // Max ply reached
-    if (data.ply >= Board::MAX_PLY) {
+    if (data.ply >= MAX_PLY) {
         return is_in_check ? 0 : standpat;
+    }
+
+    // Probes table
+    auto [table_hit, table_entry] = this->table.get(data.board.get_hash());
+
+    u16 table_move = move::NONE_MOVE;
+
+    if (table_hit) {
+        table_move = table_entry->get_move();
+
+        u8 table_bound = table_entry->get_bound();
+        i32 table_score = table_entry->get_score(data.ply);
+        i32 table_depth = table_entry->get_depth();
+
+        // Returns when score is exact or produces a cutoff
+        if ((table_bound == transposition::bound::EXACT) ||
+            (table_bound == transposition::bound::LOWER && table_score >= beta) ||
+            (table_bound == transposition::bound::UPPER && table_score <= alpha)) {
+            return table_score;
+        }
     }
 
     // Updates best eval based on if we're in check
     i32 best;
+    u16 best_move = move::NONE_MOVE;
+
+    i32 alpha_old = alpha;
 
     if (is_in_check) {
         // Possible mate here
-        best = -eval::score::INFINITE;
+        best = -eval::score::MATE + data.ply;
     }
     else {
         best = standpat;
@@ -296,15 +400,14 @@ i32 qsearch(Data& data, i32 alpha, i32 beta, std::atomic_flag& running)
         }
     }
 
-    // Generates noisy moves
-    // If we're in check, generates all legal moves
+    // If we're in check, generates all legal moves, else generates noisy moves
     auto moves = 
         is_in_check ?
         move::generate::get_legal<move::generate::type::ALL>(data.board) :
         move::generate::get_legal<move::generate::type::NOISY>(data.board);
     
     // Scores moves
-    auto moves_scores = move::order::get_score(moves, data);
+    auto moves_scores = move::order::get_score(moves, data, table_move);
 
     // Makes moves
     for (usize i = 0; i < moves.size(); ++i) {
@@ -316,11 +419,16 @@ i32 qsearch(Data& data, i32 alpha, i32 beta, std::atomic_flag& running)
         data.ply += 1;
 
         // Searches deeper
-        i32 score = -search::qsearch(data, -beta, -alpha, running);
+        i32 score = -this->qsearch(data, -beta, -alpha, pv_next);
 
         // Unmakes
         data.board.unmake(moves[i]);
         data.ply -= 1;
+
+        // Aborts search
+        if (!this->running.test()) {
+            return eval::score::DRAW;
+        }
 
         // Updates values
         if (score > best) {
@@ -328,9 +436,9 @@ i32 qsearch(Data& data, i32 alpha, i32 beta, std::atomic_flag& running)
 
             if (score > alpha) {
                 alpha = score;
-    
+
                 // Updates pv line
-                data.pv_table[data.ply].update(moves[i], data.pv_table[data.ply + 1]);
+                pv.update(moves[i], pv_next);
             }
         }
 
@@ -340,10 +448,13 @@ i32 qsearch(Data& data, i32 alpha, i32 beta, std::atomic_flag& running)
         }
     }
 
-    // Special case if we are in check
-    if (is_in_check && moves.size() == 0) {
-        return -eval::score::MATE + data.ply;
-    }
+    // Updates table
+    u8 bound =
+        best >= beta ? transposition::bound::LOWER :
+        best > alpha_old ? transposition::bound::EXACT :
+        transposition::bound::UPPER;
+    
+    table_entry->set(data.board.get_hash(), best_move, best, eval::score::NONE, 0, true, bound, data.ply, this->table.age);
 
     return best;
 };

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -192,10 +192,6 @@ i32 Engine::negamax(Data& data, i32 alpha, i32 beta, i32 depth, PV& pv)
     data.nodes += 1;
     data.seldepth = std::max(data.seldepth, data.ply);
 
-    // Init pv
-    pv.count = 0;
-    auto pv_next = PV();
-
     // Checks drawn
     if (data.board.is_drawn_repitition() || data.board.is_drawn_fifty_move() || data.board.is_drawn_insufficient()) {
         return i32(data.nodes & 0b10) - 1;
@@ -232,7 +228,10 @@ i32 Engine::negamax(Data& data, i32 alpha, i32 beta, i32 depth, PV& pv)
         }
     }
 
-    // Best score
+    // Inits data
+    pv.count = 0;
+    auto pv_next = PV();
+
     i32 best = -eval::score::INFINITE;
     u16 best_move = move::NONE_MOVE;
 
@@ -341,10 +340,6 @@ i32 Engine::qsearch(Data& data, i32 alpha, i32 beta, PV& pv)
     data.nodes += 1;
     data.seldepth = std::max(data.seldepth, data.ply);
 
-    // Init pv
-    pv.count = 0;
-    auto pv_next = PV();
-
     // Checks if we're in check
     bool is_in_check = data.board.is_in_check(data.board.get_color());
 
@@ -376,7 +371,10 @@ i32 Engine::qsearch(Data& data, i32 alpha, i32 beta, PV& pv)
         }
     }
 
-    // Updates best eval based on if we're in check
+    // Inits data
+    pv.count = 0;
+    auto pv_next = PV();
+
     i32 best;
     u16 best_move = move::NONE_MOVE;
 

--- a/src/search.h
+++ b/src/search.h
@@ -6,11 +6,12 @@
 #include "eval.h"
 #include "order.h"
 #include "timer.h"
+#include "transposition.h"
 
 namespace search
 {
 
-struct Info
+struct Settings
 {
     i32 depth;
     u64 time[2];
@@ -22,7 +23,7 @@ struct Info
 class PV
 {
 public:
-    u16 data[Board::MAX_PLY] = { move::NONE_MOVE };
+    u16 data[MAX_PLY] = { move::NONE_MOVE };
     i32 count = 0;
 public:
     PV();
@@ -34,14 +35,14 @@ public:
 class Data
 {
 public:
-    PV pv_table[Board::MAX_PLY];
-    u16 killer_table[Board::MAX_PLY];
+    u16 killer_table[MAX_PLY];
     i32 history_table[12][64];
 public:
     Board board;
     i32 ply;
 public:
     u64 nodes;
+    i32 seldepth;
 public:
     void clear();
 };
@@ -51,17 +52,22 @@ class Engine
 private:
     std::atomic_flag running;
     std::thread* thread;
+private:
+    u64 time_end_soft;
+    u64 time_end_hard;
+public:
+    transposition::Table table;
 public:
     Engine();
 public:
+    void init();
     void clear();
-    bool search(Board board, Info info);
+    bool search(Board board, Settings info);
     bool stop();
     bool join();
+public:
+    i32 negamax(Data& data, i32 alpha, i32 beta, i32 depth, PV& pv);
+    i32 qsearch(Data& data, i32 alpha, i32 beta, PV& pv);
 };
-
-i32 negamax(Data& data, i32 alpha, i32 beta, i32 depth, std::atomic_flag& running);
-
-i32 qsearch(Data& data, i32 alpha, i32 beta, std::atomic_flag& running);
 
 };

--- a/src/search.h
+++ b/src/search.h
@@ -11,6 +11,13 @@
 namespace search
 {
 
+enum class node
+{
+    ROOT,
+    PV,
+    NORMAL
+};
+
 struct Settings
 {
     i32 depth;
@@ -66,7 +73,8 @@ public:
     bool stop();
     bool join();
 public:
-    i32 negamax(Data& data, i32 alpha, i32 beta, i32 depth, PV& pv);
+    template <node NODE>
+    i32 pvsearch(Data& data, i32 alpha, i32 beta, i32 depth, PV& pv);
     i32 qsearch(Data& data, i32 alpha, i32 beta, PV& pv);
 };
 

--- a/src/timer.h
+++ b/src/timer.h
@@ -5,11 +5,21 @@
 namespace timer
 {
 
-inline u64 get_available(u64 remain, u64 increment, std::optional<u64> movestogo = {})
+inline u64 get_current()
+{
+    return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+};
+
+inline u64 get_available_soft(u64 remain, u64 increment, std::optional<u64> movestogo = {})
 {
     u64 mtg = movestogo.value_or(45) + 5;
 
     return (remain - increment) / mtg + increment / 2;
+};
+
+inline u64 get_available_hard(u64 remain)
+{
+    return remain / 2;
 };
 
 };

--- a/src/transposition.cpp
+++ b/src/transposition.cpp
@@ -1,0 +1,222 @@
+#include "transposition.h"
+
+namespace transposition
+{
+
+u16 Entry::get_hash()
+{
+    return this->hash;
+};
+
+u16 Entry::get_move()
+{
+    return this->move;
+};
+
+i32 Entry::get_score(i32 ply)
+{
+    if (this->score == eval::score::NONE) {
+        return this->score;
+    }
+
+    // Mate scores need to be adjusted
+    // Otherwise, we will not know if we have a faster or slower mate
+    if (this->score >= eval::score::MATE_FOUND) {
+        return this->score - ply;
+    }
+    else if (this->score <= -eval::score::MATE_FOUND) {
+        return this->score + ply;
+    }
+
+    return this->score;
+};
+
+i32 Entry::get_eval()
+{
+    return this->eval;
+};
+
+i32 Entry::get_depth()
+{
+    return this->depth;
+};
+
+u8 Entry::get_age()
+{
+    return this->flags >> 3;
+};
+
+u8 Entry::get_bound()
+{
+    return this->flags & mask::BOUND;
+};
+
+i32 Entry::get_age_distance(u8 table_age)
+{
+    return (MAX_AGE + table_age - this->get_age()) % MAX_AGE;
+};
+
+void Entry::set_score(i32 score, i32 ply)
+{
+    // Mate scores need to be adjusted
+    if (score != eval::score::NONE) {
+        if (score >= eval::score::MATE_FOUND) {
+            score += ply;
+        }
+        else if (score <= -eval::score::MATE_FOUND) {
+            score -= ply;
+        }
+    }
+
+    this->score = score;
+};
+
+void Entry::set(u64 hash, u16 move, i32 score, i32 eval, i32 depth, bool pv, u8 bound, i32 ply, u8 table_age)
+{
+    // Preserves any existing move for the same position
+    if (move || this->hash != static_cast<u16>(hash)) {
+        this->move = move;
+    }
+
+    // Overwrites less valuable entry
+    if (bound == bound::EXACT ||
+        this->hash != static_cast<u16>(hash) ||
+        this->get_age() != table_age ||
+        depth + 4 + static_cast<u8>(pv) * 2 > this->depth) {
+        this->hash = static_cast<u16>(hash);
+        this->depth = static_cast<u8>(depth);
+        this->set_score(score, ply);
+        this->eval = eval;
+        this->flags = bound | (static_cast<u8>(pv) << 2) | (table_age << 3);
+    }
+};
+
+bool Entry::is_pv()
+{
+    return this->flags & mask::PV;
+};
+
+Table::Table()
+{
+    this->buckets = nullptr;
+    this->count = 0;
+    this->age = 0;
+};
+
+Table::~Table()
+{
+    if (this->buckets != nullptr) {
+        free_aligned(this->buckets);
+    }
+};
+
+void Table::init(u64 mb)
+{
+    // Free memory if there is any
+    if (this->buckets != nullptr) {
+        free_aligned(this->buckets);
+    }
+
+    // Sets count
+    this->count = mb * MB / sizeof(Bucket);
+    
+    // Alloc memory
+    #if defined(__linux__)
+    u64 alignment = 2 * MB;
+    #else
+    u64 alignment = 4 * KB;
+    #endif
+
+    this->buckets = static_cast<Bucket*>(malloc_aligned(alignment, mb * MB));
+
+    std::cout << "alloced " << this->buckets << std::endl;
+};
+
+void Table::clear(usize thread_count)
+{
+    this->age = 0;
+
+    if (this->buckets == nullptr) {
+        return;
+    }
+
+    const u64 chunk = this->count / thread_count;
+
+    std::vector<std::thread> threads;
+
+    for (usize i = 0; i < thread_count; ++i) {
+        threads.emplace_back([&] (usize thread_id) {
+            std::memset(&this->buckets[chunk * thread_id], 0, chunk * sizeof(Bucket));
+        }, i);
+    }
+
+    if (chunk * thread_count < this->count) {
+        std::memset(&this->buckets[chunk * thread_count], 0, (this->count - chunk * thread_count) * sizeof(Bucket));
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    std::cout << "table cleared" << std::endl;
+};
+
+std::pair<bool, Entry*> Table::get(u64 hash)
+{
+    const u64 index = this->get_index(hash);
+
+    auto entries = this->buckets[index].entries;
+
+    // Finds matching entry
+    for (usize i = 0; i < MAX_ENTRIES; ++i) {
+        if (entries[i].get_hash() == static_cast<u16>(hash)) {
+            return { true, &entries[i] };
+        }
+    }
+
+    // Finds replacement
+    auto entry = &entries[0];
+
+    for (usize i = 1; i < MAX_ENTRIES; ++i) {
+        if (entries[i].get_depth() - 8 * entries[i].get_age_distance(this->age) <
+            entry->get_depth() - 8 * entry->get_age_distance(this->age)) {
+            entry = &entries[i];
+        }
+    }
+
+    return { false, entry };
+};
+
+u64 Table::get_index(u64 hash)
+{
+    return static_cast<u64>((static_cast<u128>(hash) * static_cast<u128>(this->count)) >> 64);
+};
+
+void Table::update()
+{
+    this->age = (this->age + 1) % MAX_AGE;
+};
+
+void Table::prefetch(u64 hash)
+{
+    __builtin_prefetch(&this->buckets[this->get_index(hash)]);
+};
+
+usize Table::hashfull()
+{
+    usize count = 0;
+
+    for (usize i = 0; i < 1000; ++i) {
+        for (usize k = 0; k < MAX_ENTRIES; ++k) {
+            if (this->buckets[i].entries[k].get_age() == this->age &&
+                this->buckets[i].entries[k].get_hash() != 0) {
+                count += 1;
+            }
+        }
+    }
+
+    return count / MAX_ENTRIES;
+};
+
+
+};

--- a/src/transposition.cpp
+++ b/src/transposition.cpp
@@ -82,7 +82,7 @@ void Entry::set(u64 hash, u16 move, i32 score, i32 eval, i32 depth, bool pv, u8 
     if (bound == bound::EXACT ||
         this->hash != static_cast<u16>(hash) ||
         this->get_age() != table_age ||
-        depth + 4 + static_cast<u8>(pv) * 2 > this->depth) {
+        depth + 4 + static_cast<i32>(pv) * 2 > this->depth) {
         this->hash = static_cast<u16>(hash);
         this->depth = static_cast<u8>(depth);
         this->set_score(score, ply);
@@ -129,13 +129,13 @@ void Table::init(u64 mb)
 
     this->buckets = static_cast<Bucket*>(malloc_aligned(alignment, mb * MB));
 
+    this->age = 0;
+
     std::cout << "alloced " << this->buckets << std::endl;
 };
 
 void Table::clear(usize thread_count)
 {
-    this->age = 0;
-
     if (this->buckets == nullptr) {
         return;
     }

--- a/src/transposition.cpp
+++ b/src/transposition.cpp
@@ -43,7 +43,7 @@ i32 Entry::get_depth()
 
 u8 Entry::get_age()
 {
-    return this->flags >> 3;
+    return this->flags >> 2;
 };
 
 u8 Entry::get_bound()
@@ -71,7 +71,7 @@ void Entry::set_score(i32 score, i32 ply)
     this->score = score;
 };
 
-void Entry::set(u64 hash, u16 move, i32 score, i32 eval, i32 depth, bool pv, u8 bound, i32 ply, u8 table_age)
+void Entry::set(u64 hash, u16 move, i32 score, i32 eval, i32 depth, u8 bound, i32 ply, u8 table_age)
 {
     // Preserves any existing move for the same position
     if (move || this->hash != static_cast<u16>(hash)) {
@@ -82,18 +82,13 @@ void Entry::set(u64 hash, u16 move, i32 score, i32 eval, i32 depth, bool pv, u8 
     if (bound == bound::EXACT ||
         this->hash != static_cast<u16>(hash) ||
         this->get_age() != table_age ||
-        depth + 4 + static_cast<i32>(pv) * 2 > this->depth) {
+        depth + 4 > this->depth) {
         this->hash = static_cast<u16>(hash);
         this->depth = static_cast<u8>(depth);
         this->set_score(score, ply);
         this->eval = eval;
-        this->flags = bound | (static_cast<u8>(pv) << 2) | (table_age << 3);
+        this->flags = bound | (table_age << 2);
     }
-};
-
-bool Entry::is_pv()
-{
-    return this->flags & mask::PV;
 };
 
 Table::Table()
@@ -178,8 +173,8 @@ std::pair<bool, Entry*> Table::get(u64 hash)
     auto entry = &entries[0];
 
     for (usize i = 1; i < MAX_ENTRIES; ++i) {
-        if (entries[i].get_depth() - 8 * entries[i].get_age_distance(this->age) <
-            entry->get_depth() - 8 * entry->get_age_distance(this->age)) {
+        if (entries[i].get_depth() - 4 * entries[i].get_age_distance(this->age) <
+            entry->get_depth() - 4 * entry->get_age_distance(this->age)) {
             entry = &entries[i];
         }
     }

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -23,14 +23,13 @@ constexpr u8 EXACT = 3;
 namespace mask
 {
 
-constexpr u8 AGE = 0b11111000;
-constexpr u8 PV = 0b100;
+constexpr u8 AGE = 0b11111100;
 constexpr u8 BOUND = 0b11;
 
 };
 
 constexpr usize MAX_ENTRIES = 3;
-constexpr u8 MAX_AGE = 1 << 5;
+constexpr u8 MAX_AGE = 1 << 6;
 
 constexpr u64 KB = 1ULL << 10;
 constexpr u64 MB = 1ULL << 20;
@@ -43,7 +42,7 @@ private:
     i16 score = 0;
     i16 eval = 0;
     u8 depth = 0;
-    u8 flags = 0;
+    u8 flags = 0; // age : 6, bound : 2
 public:
     u16 get_hash();
     u16 get_move();
@@ -55,9 +54,7 @@ public:
     i32 get_age_distance(u8 table_age);
 public:
     void set_score(i32 score, i32 ply);
-    void set(u64 hash, u16 move, i32 score, i32 eval, i32 depth, bool pv, u8 bound, i32 ply, u8 table_age);
-public:
-    bool is_pv();
+    void set(u64 hash, u16 move, i32 score, i32 eval, i32 depth, u8 bound, i32 ply, u8 table_age);
 };
 
 struct alignas(32) Bucket
@@ -89,29 +86,5 @@ public:
 
 static_assert(sizeof(Entry) == 10);
 static_assert(sizeof(Bucket) == 32);
-
-inline i32 get_score_from(i32 score, i32 ply)
-{
-    if (score > eval::score::MATE_FOUND) {
-        score -= ply;
-    }
-    else if (score < -eval::score::MATE_FOUND) {
-        score += ply;
-    }
-
-    return score;
-};
-
-inline i32 get_score_to(i32 score, i32 ply)
-{
-    if (score > eval::score::MATE_FOUND) {
-        score += ply;
-    }
-    else if (score < -eval::score::MATE_FOUND) {
-        score -= ply;
-    }
-
-    return score;
-};
 
 };

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <thread>
+#include <climits>
+#include <cstring>
+
+#include "util/alloc.h"
+#include "eval.h"
+
+namespace transposition
+{
+
+namespace bound
+{
+
+constexpr u8 NONE = 0;
+constexpr u8 UPPER = 1;
+constexpr u8 LOWER = 2;
+constexpr u8 EXACT = 3;
+
+};
+
+namespace mask
+{
+
+constexpr u8 AGE = 0b11111000;
+constexpr u8 PV = 0b100;
+constexpr u8 BOUND = 0b11;
+
+};
+
+constexpr usize MAX_ENTRIES = 3;
+constexpr u8 MAX_AGE = 1 << 5;
+
+constexpr u64 KB = 1ULL << 10;
+constexpr u64 MB = 1ULL << 20;
+
+class Entry
+{
+private:
+    u16 hash = 0;
+    u16 move = move::NONE_MOVE;
+    i16 score = 0;
+    i16 eval = 0;
+    u8 depth = 0;
+    u8 flags = 0;
+public:
+    u16 get_hash();
+    u16 get_move();
+    i32 get_score(i32 ply);
+    i32 get_eval();
+    i32 get_depth();
+    u8 get_age();
+    u8 get_bound();
+    i32 get_age_distance(u8 table_age);
+public:
+    void set_score(i32 score, i32 ply);
+    void set(u64 hash, u16 move, i32 score, i32 eval, i32 depth, bool pv, u8 bound, i32 ply, u8 table_age);
+public:
+    bool is_pv();
+};
+
+struct alignas(32) Bucket
+{
+    Entry entries[MAX_ENTRIES];
+    u16 padding;
+};
+
+class Table
+{
+public:
+    Bucket* buckets;
+    u64 count;
+    u8 age;
+public:
+    Table();
+    ~Table();
+public:
+    void init(u64 mb);
+    void clear(usize thread_count = 1);
+public:
+    std::pair<bool, Entry*> get(u64 hash);
+    u64 get_index(u64 hash);
+public:
+    void update();
+    void prefetch(u64 hash);
+    usize hashfull();
+};
+
+static_assert(sizeof(Entry) == 10);
+static_assert(sizeof(Bucket) == 32);
+
+inline i32 get_score_from(i32 score, i32 ply)
+{
+    if (score > eval::score::MATE_FOUND) {
+        score -= ply;
+    }
+    else if (score < -eval::score::MATE_FOUND) {
+        score += ply;
+    }
+
+    return score;
+};
+
+inline i32 get_score_to(i32 score, i32 ply)
+{
+    if (score > eval::score::MATE_FOUND) {
+        score += ply;
+    }
+    else if (score < -eval::score::MATE_FOUND) {
+        score -= ply;
+    }
+
+    return score;
+};
+
+};

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -104,10 +104,10 @@ std::optional<Board> get_command_position(std::string in)
     return board;
 };
 
-std::optional<search::Info> get_command_go(std::string in)
+std::optional<search::Settings> get_command_go(std::string in)
 {
-    auto info = search::Info {
-        .depth = Board::MAX_PLY,
+    auto info = search::Settings {
+        .depth = MAX_PLY,
         .time = { 0, 0 },
         .inc = { 0, 0 },
         .movestogo = {},
@@ -155,13 +155,15 @@ std::optional<search::Info> get_command_go(std::string in)
     return info;
 };
 
-void print_info(i32 depth, i32 score, u64 nodes, u64 ms, search::PV pv)
+void print_info(i32 depth, i32 seldepth, i32 score, u64 nodes, u64 ms, u64 hashfull, search::PV pv)
 {
     std::cout << "info ";
 
     std::cout << "depth " << depth << " ";
 
-    if (score >= eval::score::MATE - Board::MAX_PLY || score <= -eval::score::MATE + Board::MAX_PLY) {
+    std::cout << "seldepth " << seldepth << " ";
+
+    if (score >= eval::score::MATE - MAX_PLY || score <= -eval::score::MATE + MAX_PLY) {
         std::cout << "score mate " << (std::abs(eval::score::MATE - std::abs(score)) / 2) << " ";
     }
     else {
@@ -171,6 +173,8 @@ void print_info(i32 depth, i32 score, u64 nodes, u64 ms, search::PV pv)
     std::cout << "nodes " << nodes << " ";
 
     std::cout << "nps " << (nodes * 1000 / std::max(ms, 1ULL)) << " ";
+
+    std::cout << "hashfull " << hashfull <<  " ";
 
     std::cout << "pv ";
     

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -163,8 +163,8 @@ void print_info(i32 depth, i32 seldepth, i32 score, u64 nodes, u64 ms, u64 hashf
 
     std::cout << "seldepth " << seldepth << " ";
 
-    if (score >= eval::score::MATE - MAX_PLY || score <= -eval::score::MATE + MAX_PLY) {
-        std::cout << "score mate " << (std::abs(eval::score::MATE - std::abs(score)) / 2) << " ";
+    if (score >= eval::score::MATE_FOUND || score <= -eval::score::MATE_FOUND) {
+        std::cout << "score mate " << ((eval::score::MATE - score) / 2) << " ";
     }
     else {
         std::cout << "score cp " << score << " ";

--- a/src/uci.h
+++ b/src/uci.h
@@ -9,9 +9,9 @@ std::optional<u16> get_move(const std::string& token, Board& board);
 
 std::optional<Board> get_command_position(std::string in);
 
-std::optional<search::Info> get_command_go(std::string in);
+std::optional<search::Settings> get_command_go(std::string in);
 
-void print_info(i32 depth, i32 score, u64 nodes, u64 ms, search::PV pv);
+void print_info(i32 depth, i32 seldepth, i32 score, u64 nodes, u64 ms, u64 hashfull, search::PV pv);
 
 void print_bestmove(u16 move);
 

--- a/src/util/alloc.h
+++ b/src/util/alloc.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <iostream>
+#include <cstdio>
+#include <cstdint>
+#include <cstddef>
+#include <cstdlib>
+#include <cassert>
+
+#if defined(__linux__)
+#include <sys/mman.h>
+#endif
+
+using usize = size_t;
+
+inline void* malloc_aligned(usize alignment, usize size)
+{
+    void* ptr;
+
+#if defined(__MINGW32__)
+    ptr = _aligned_malloc(size, alignment);
+#elif defined (__GNUC__)
+    ptr = std::aligned_alloc(alignment, size);
+#else
+#error "Unsupported complier!"
+#endif
+
+#if defined(__linux__)
+    madvise(ptr, size, MADV_HUGEPAGE);
+#endif 
+
+    return ptr;
+};
+
+inline void free_aligned(void* ptr)
+{
+#if defined(__MINGW32__)
+    _aligned_free(ptr);
+#elif defined (__GNUC__)
+    std::free(ptr);
+#else
+#error "Unsupported complier!"
+#endif
+};


### PR DESCRIPTION
Results against no transposition table:
```
Score of blueberry tt vs blueberry nott: 99 - 1 - 12  [0.938] 112
...      blueberry tt playing White: 50 - 0 - 6  [0.946] 56
...      blueberry tt playing Black: 49 - 1 - 6  [0.929] 56
...      White vs Black: 51 - 49 - 12  [0.509] 112
Elo difference: 470.4 +/- 108.1, LOS: 100.0 %, DrawRatio: 10.7 %
SPRT: llr 2.97 (101.0%), lbound -2.94, ubound 2.94 - H1 was accepted
```
Honestly, I think this gain is more due to bugs fixes rather than transposition table, but I'll take it.
Got decent speed up also.