### PR TITLE
skip in see pruning

### DIFF
--- a/src/engine/order.cpp
+++ b/src/engine/order.cpp
@@ -6,10 +6,6 @@ namespace move::order
 
 arrayvec<i32, move::MAX> get_score(const arrayvec<u16, move::MAX>& moves, search::Data& data, u16 hash_move)
 {
-    constexpr i32 HASH_SCORE = 10000000;
-    constexpr i32 NOISY_SCORE = 1000000;
-    constexpr i32 KILLER_SCORE = 90000;
-
     auto scores = arrayvec<i32, move::MAX>();
 
     for (usize i = 0; i < moves.size(); ++i) {

--- a/src/engine/order.h
+++ b/src/engine/order.h
@@ -12,6 +12,10 @@ class Data;
 namespace move::order
 {
 
+constexpr i32 HASH_SCORE = 10000000;
+constexpr i32 NOISY_SCORE = 1000000;
+constexpr i32 KILLER_SCORE = 90000;
+
 arrayvec<i32, move::MAX> get_score(const arrayvec<u16, move::MAX>& moves, search::Data& data, u16 hash_move);
 
 void sort(arrayvec<u16, move::MAX>& moves, arrayvec<i32, move::MAX>& scores, usize index);

--- a/src/engine/search.cpp
+++ b/src/engine/search.cpp
@@ -512,7 +512,7 @@ i32 Engine::pvsearch(Data& data, i32 alpha, i32 beta, i32 depth)
                 params::see::MARGIN_QUIET * lmr_depth :
                 params::see::MARGIN_NOISY * lmr_depth * lmr_depth;
             
-            if (!eval::is_see(data.board, moves[i], see_margin)) {
+            if (moves_scores[i] < move::order::KILLER_SCORE && !eval::is_see(data.board, moves[i], see_margin)) {
                 continue;
             }
         }

--- a/src/engine/search.h
+++ b/src/engine/search.h
@@ -56,6 +56,7 @@ namespace hp
 namespace lmr
 {
     constexpr i32 DEPTH = 3;
+    constexpr i32 HISTORY_DIVISOR_QUIET = 8192;
 };
 
 namespace see


### PR DESCRIPTION
if the move score is bigger than killer move score, we know for sure it beat see, so we don't evaluate it

Score of new vs main: 505 - 401 - 695  [0.532] 1601
...      new playing White: 251 - 207 - 343  [0.527] 801
...      new playing Black: 254 - 194 - 352  [0.537] 800
...      White vs Black: 445 - 461 - 695  [0.495] 1601
Elo difference: 22.6 +/- 12.8